### PR TITLE
Updating to JDK 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,19 @@ Because ZomboidDoc reads directly from game code the compiled Lua library is gua
 ### Prerequisites
 
 - Project Zomboid[<sup>?</sup>](#requirements "tested with 41.50-IWBUMS")
-- [JDK 8](https://adoptopenjdk.net/?variant=openjdk8&jvmVariant=hotspot)[<sup>?</sup>](#requirements "tested with OpenJDK 1.8.0_282")
+- [JDK 17](https://adoptopenjdk.net/?variant=openjdk17&jvmVariant=hotspot)[<sup>?</sup>](#requirements "tested with OpenJDK 17.0.7+7")
+  
+### Config
+
+**Changing the Gradle JVM to version 17**
+  
+1) Go to File/Settings on the IntelliJ settings.
+2) Navigate to Build, Execution, Deployment/Build Tools/Gradle
+3) Set "Gradle JVM" to JDK 17
+
+**Setting project SDK to version 17**
+1) Go to File/Project Structure/Project
+2) Set "Project SDK" to the same version as your Gradle JDK
 
 ### Gradle
 

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ application {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(8))
+        languageVersion.set(JavaLanguageVersion.of(17))
         vendor = JvmVendorSpec.ADOPTOPENJDK
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 distributionSha256Sum=1433372d903ffba27496f8d5af24265310d2da0d78bf6b4e5138831d4fe066e9

--- a/zomboid.gradle
+++ b/zomboid.gradle
@@ -25,7 +25,7 @@ tasks.register('decompileZomboid', JavaExec.class) {
 	}
 	//noinspection GroovyAssignabilityCheck,GroovyAccessibility
 	it.javaLauncher = javaToolchains.launcherFor {
-		languageVersion = JavaLanguageVersion.of(11)
+		languageVersion = JavaLanguageVersion.of(17)
 	}
     it.classpath files("$ideaHome/plugins/java-decompiler/lib/java-decompiler.jar")
     it.main 'org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler'


### PR DESCRIPTION
It updates the config files to run with the JDK 17 and Gradle 7.4.2 in order to be able to decompile the source of the game that has been updated since this tool was created.